### PR TITLE
[kcalcore] "meego port" version of kDebug require to be explicitly turned on

### DIFF
--- a/kcalcore/klibport/meego_port.cpp
+++ b/kcalcore/klibport/meego_port.cpp
@@ -31,6 +31,31 @@ KLocale* KGlobal::locale()
   return plocale;
 }
 
+
+class KNoDebugStream: public QIODevice
+{
+  // Q_OBJECT
+public:
+  KNoDebugStream() { open(WriteOnly); }
+  bool isSequential() const { return true; }
+  qint64 readData(char *, qint64) { return 0; /* eof */ }
+  qint64 readLineData(char *, qint64) { return 0; /* eof */ }
+  qint64 writeData(const char *, qint64 len) { return len; }
+};
+
+QDebug kCalcoreDebug(const char *filename, int line)
+{
+  static bool enabled = (getenv("KCALDEBUG") != 0 && !QString(getenv("KCALDEBUG")).isEmpty());
+  static KNoDebugStream noDebug;
+
+  if (enabled) {
+    return qDebug() << filename << ":" << line << "-";
+  }
+
+  return QDebug(&noDebug);
+}
+
+
 static inline void put_it_in( QChar *buffer, int& index, const QString &s )
 {
   for ( int l = 0; l < s.length(); l++ )

--- a/kcalcore/klibport/meego_port.h
+++ b/kcalcore/klibport/meego_port.h
@@ -40,9 +40,11 @@
 
 #include <cstdlib>
 
-#define kDebug(x) qDebug() << __FILE__":" << __LINE__ << "-"
+#define kDebug(x) kCalcoreDebug(__FILE__, __LINE__)
 #define kWarning(x) qWarning() << __FILE__":" << __LINE__ << "-"
 #define kError(x) qCritical() << __FILE__":" << __LINE__ << "-"
+
+QDebug kCalcoreDebug(const char * filename, int line);
 
 
 class KStringHandler 


### PR DESCRIPTION
Especially Mkcal is quite chatty on debug output. Avoid flooding the
console by requiring KCALDEBUG environment variable to be set
non-empty.
