### PR TITLE
Fix wrong UTC offset reporting

### DIFF
--- a/kcalcore/kdedate/kdatetime.cpp
+++ b/kcalcore/kdedate/kdatetime.cpp
@@ -2827,7 +2827,7 @@ bool getUTCOffset(const QString &string, int &offset, bool colon, int &result)
     tzmin += tzhour * 60;
     if (result != NO_NUMBER  &&  result != tzmin)
         return false;
-    result = tzmin;
+    result = sign * tzmin;
     return true;
 }
 


### PR DESCRIPTION
This bug is what causes https://together.jolla.com/question/39236/bug-google-calendar-events-off-by-12-hours/ and was actually fixed upstream http://marc.info/?l=kde-core-devel&m=134973661628231&w=2

The best way to fix it would be to sync with upstream but this version of kcalcore seems really old and I'd really like to see this bug fixed on my Jolla so I'm doing this pull request.
