### PR TITLE
[kcalcore] Properly link against libuuid which is used by kcalcore

### DIFF
--- a/kcalcore/kcalcore.pro
+++ b/kcalcore/kcalcore.pro
@@ -7,7 +7,7 @@ INCLUDEPATH += . versit klibport kdedate tests /usr/include/libical
 VERSION += 4.10.2
 
 CONFIG += link_pkgconfig
-PKGCONFIG += libical
+PKGCONFIG += libical uuid
 #equals(QT_MAJOR_VERSION, 4): PKGCONFIG += timed
 
 DEFINES += MEEGO \


### PR DESCRIPTION
Build package requirement was there, but pkgconfig missing.
Thus the resulting library didn't link against libuuid, requiring
code using kcalcore to do it.