### PR TITLE
[kcalcore] Calculate LocalTime from UTC DTSTART when parsing phases. Contributes to MER#1011

### DIFF
--- a/kcalcore/icaltimezones.cpp
+++ b/kcalcore/icaltimezones.cpp
@@ -1313,10 +1313,10 @@ QList<QDateTime> ICalTimeZoneSourcePrivate::parsePhase( icalcomponent *c,
   }
 
   // Convert DTSTART to QDateTime, and from local time to UTC
-  const QDateTime localStart = toQDateTime( dtstart );   // local time
   dtstart.second -= prevOffset;
   dtstart.is_utc = 1;
   const QDateTime utcStart = toQDateTime( icaltime_normalize( dtstart ) );   // UTC
+  const QDateTime localStart = utcStart.toLocalTime();  // local time
 
   transitions += utcStart;
   if ( recurs ) {


### PR DESCRIPTION
This commit ensures that the interval within which transitions are
determined (from the RRULE) is fully-specified, otherwise the interval
is considered null and thus no transitions are deemed to occur.

Previously, the start of the interval is set to the DTSTART value,
but if that DTSTART value is specified in UTC format, this fails due
to a bad conversion to local time.

This commit ensures that the start of the interval is calculated
(in local time) from the (correctly parsed) UTC DTSTART value.

Contributes to MER#1011